### PR TITLE
Backup improvement

### DIFF
--- a/backup/backup-container/Dockerfile
+++ b/backup/backup-container/Dockerfile
@@ -4,11 +4,10 @@ COPY entrypoint.sh /
 
 RUN \
 	mkdir -p /data/backup /aws /backups && \
-	apk -Uuv add python3 py-pip && \
-	pip install awscli && \
-	apk --purge -v del py-pip && \
+	apk -Uuv add python3 py3-pip && \
+	pip3 install awscli six && \
+	apk --purge -v del py3-pip && \
 	rm /var/cache/apk/* && \
   chmod +x /entrypoint.sh
-
 
 ENTRYPOINT /entrypoint.sh

--- a/backup/backup-container/Dockerfile
+++ b/backup/backup-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.12.0
 
 COPY entrypoint.sh /
 

--- a/backup/backup-container/entrypoint.sh
+++ b/backup/backup-container/entrypoint.sh
@@ -1,28 +1,37 @@
 #!/bin/sh
 
-BACKUP_FILE_NAME="${BACKUP_NAME}-$(date "+%Y-%m-%d_%H-%M-%S").tar.gz"
+set -e
+
+BACKUP_TIME=$(date "+%Y-%m-%d_%H-%M")
+
+BACKUP_FILE_NAME="${BACKUP_NAME}-${BACKUP_TIME}.tar.gz"
 BACKUP_FILE_PATH="${BACKUP_BASE_PATH}/${BACKUP_FILE_NAME}"
 
-BACKUP_RUNTIME_FILE_NAME="${BACKUP_RUNTIME_NAME}-$(date "+%Y-%m-%d_%H-%M-%S").tar.gz"
+BACKUP_RUNTIME_FILE_NAME="${BACKUP_RUNTIME_NAME}-${BACKUP_TIME}.tar.gz"
 BACKUP_RUNTIME_FILE_PATH="${BACKUP_BASE_PATH}/${BACKUP_RUNTIME_FILE_NAME}"
 
-tar -zcvf "${BACKUP_FILE_PATH}" "${FOLDERS_TO_BACKUP}"
+tar -zcvf "${BACKUP_FILE_PATH}" "${BLAZEGRAPH_BACKUP}"
 tar -zcvf "${BACKUP_RUNTIME_FILE_PATH}" "${FOLDERS_TO_BACKUP_RUNTIME}"
 
 if [ -z "${S3_BUCKET_URL}" ]; then
-	echo "No S3 BUCKET specified. Skipping S3 backup."
+    echo "No S3 BUCKET specified. Skipping S3 backup."
 fi
 if [ -n "${S3_BUCKET_URL}" ]; then
-	echo "Uploading backup archive ${BACKUP_FILE_PATH} to S3 ${S3_BUCKET_URL}"
-	aws s3 cp "${BACKUP_FILE_PATH}" "${S3_BUCKET_URL}" --quiet --endpoint-url "${ENDPOINT_URL}"
+    echo "Uploading backup archive ${BACKUP_FILE_PATH} to S3 ${S3_BUCKET_URL}"
+    aws s3 cp --quiet "${BACKUP_FILE_PATH}" "${S3_BUCKET_URL}" --endpoint-url "${ENDPOINT_URL}"
 
-	echo "Uploading runtime backup archive ${BACKUP_RUNTIME_FILE_PATH} to S3 ${S3_BUCKET_URL}"
-	aws s3 cp "${BACKUP_RUNTIME_FILE_PATH}" "${S3_BUCKET_URL}" --quiet --endpoint-url "${ENDPOINT_URL}"
+    echo "Uploading runtime backup archive ${BACKUP_RUNTIME_FILE_PATH} to S3 ${S3_BUCKET_URL}"
+    aws s3 cp --quiet "${BACKUP_RUNTIME_FILE_PATH}" "${S3_BUCKET_URL}" --endpoint-url "${ENDPOINT_URL}"
 fi
 
 if [ -n "${KEEP_BACKUP_DAYS}" ]; then
-	echo "Removing old backups. Only keeping backups created in the last ${KEEP_BACKUP_DAYS} days."
-	find "${BACKUP_BASE_PATH}" -mtime "+${KEEP_BACKUP_DAYS}" -type f -delete;
+    echo "Removing old backups. Only keeping backups created in the last ${KEEP_BACKUP_DAYS} days."
+    find "${BACKUP_BASE_PATH}" -mtime "+${KEEP_BACKUP_DAYS}" -type f -delete;
 else
-	echo "KEEP_BACKUP_DAYS was not set. Not removing any old backups."
+    echo "KEEP_BACKUP_DAYS was not set. Not removing any old backups."
 fi
+
+# remove current Blazegraph backup file, because Blazegraph doesn't support overwriting them
+rm ${BLAZEGRAPH_BACKUP}
+
+exit 0

--- a/backup/backup-container/entrypoint.sh
+++ b/backup/backup-container/entrypoint.sh
@@ -14,20 +14,15 @@ if [ -z "${S3_BUCKET_URL}" ]; then
 fi
 if [ -n "${S3_BUCKET_URL}" ]; then
 	echo "Uploading backup archive ${BACKUP_FILE_PATH} to S3 ${S3_BUCKET_URL}"
-	aws s3 cp "${BACKUP_FILE_PATH}" "${S3_BUCKET_URL}" --endpoint-url "${ENDPOINT_URL}"
+	aws s3 cp "${BACKUP_FILE_PATH}" "${S3_BUCKET_URL}" --quiet --endpoint-url "${ENDPOINT_URL}"
 
 	echo "Uploading runtime backup archive ${BACKUP_RUNTIME_FILE_PATH} to S3 ${S3_BUCKET_URL}"
-        aws s3 cp "${BACKUP_RUNTIME_FILE_PATH}" "${S3_BUCKET_URL}" --endpoint-url "${ENDPOINT_URL}"
-
+	aws s3 cp "${BACKUP_RUNTIME_FILE_PATH}" "${S3_BUCKET_URL}" --quiet --endpoint-url "${ENDPOINT_URL}"
 fi
 
 if [ -n "${KEEP_BACKUP_DAYS}" ]; then
 	echo "Removing old backups. Only keeping backups created in the last ${KEEP_BACKUP_DAYS} days."
 	find "${BACKUP_BASE_PATH}" -mtime "+${KEEP_BACKUP_DAYS}" -type f -delete;
-
-	echo "Removing old runtime backups. Only keeping backups created in the last ${KEEP_BACKUP_DAYS} days."
-        find "${BACKUP_RUNTIME_BASE_PATH}" -mtime "+${KEEP_BACKUP_DAYS}" -type f -delete;
-
 else
 	echo "KEEP_BACKUP_DAYS was not set. Not removing any old backups."
 fi

--- a/backup/callToBackup.sh
+++ b/backup/callToBackup.sh
@@ -22,7 +22,7 @@ function backup {
 
     echo "-> starting online backup of Blazegraph"
     blazegraph_container_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${environment}-blazegraph)
-    curl --data-urlencode "file=/blazegraph-data/blazegraph.jnl.backup" --data-urlencode "compress=true" http://${blazegraph_container_ip}:8080/blazegraph/backup
+    curl --data-urlencode "file=/blazegraph-data/blazegraph.jnl.backup.gz" --data-urlencode "compress=true" http://${blazegraph_container_ip}:8080/blazegraph/backup
 
     echo "-> Navigating into working directory"
     currentDir="$(pwd)"

--- a/backup/callToBackup.sh
+++ b/backup/callToBackup.sh
@@ -1,19 +1,28 @@
 #!/bin/bash
+
+set -e
+
 # This file shall be executed by a cronjon to trigger the backup process
 PATH_TO_SCRIPT=/home/ubuntu/performing-arts-ch-docker-compose/backup/
 
 ### ADD THE NAME OF ANY ENVIRONMENT TO BE BACKED UP TO THIS ARRAY
 declare -a environments=(
-   # "dev"
-    "prod"
+    "dev"
+   # "prod"
 )
 
-#### START CODE, DO NOT EDIT ####
+backup_date=$(date +%Y-%m-%d_%H-%M)
 
+
+#### START CODE, DO NOT EDIT ####
 # backup function
 # takes the name of the environment as a parameter
 function backup {
-    echo "[$(date "+%Y-%m-%d")] Starting backup for ${environment}"
+    echo "[${backup_date}] Starting backup for ${environment}"
+
+    echo "-> starting online backup of Blazegraph"
+    blazegraph_container_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${environment}-blazegraph)
+    curl --data-urlencode "file=/blazegraph-data/blazegraph.jnl.backup" --data-urlencode "compress=true" http://${blazegraph_container_ip}:8080/blazegraph/backup
 
     echo "-> Navigating into working directory"
     currentDir="$(pwd)"
@@ -21,22 +30,14 @@ function backup {
 
     cd ../metaphactory-blazegraph/"${environment}"/ || return
 
-    echo "-> Shutting down metaphacts-platform containers"
-    docker-compose down
-
     echo "-> Starting cron-backup container"
     docker-compose -f ../../backup/docker-compose.yml up
 
-    echo "Starting up metaphacts-platform containers again"
-    docker-compose up -d
-
     cd "${currentDir}" || return
 
-    echo "[$(date "+%Y-%m-%d")] Finished backup for ${environment}"
+    echo "[${backup_date}] Finished backup for ${environment}"
 }
 
-
-for environment in "${environments[@]}"
-do
-  backup "${environment}"
+for environment in "${environments[@]}"; do
+    backup "${environment}"
 done

--- a/backup/docker-compose.yml
+++ b/backup/docker-compose.yml
@@ -2,6 +2,7 @@ version: "2.2"
 services:
   backup-container:
     container_name: "${COMPOSE_PROJECT_NAME}-backup-container"
+    image: "${COMPOSE_PROJECT_NAME}-backup-container"
     build:
       context: backup-container
     volumes:
@@ -14,9 +15,8 @@ services:
       - BACKUP_NAME=${COMPOSE_PROJECT_NAME}-backup
       - BACKUP_BASE_PATH=/data/backup
       - BACKUP_RUNTIME_NAME=${COMPOSE_PROJECT_NAME}-runtime-backup
-      - FOLDERS_TO_BACKUP=/data/${COMPOSE_PROJECT_NAME}/blazegraph-journal
+      - BLAZEGRAPH_BACKUP=/data/${COMPOSE_PROJECT_NAME}/blazegraph-journal/blazegraph.jnl.backup
       - FOLDERS_TO_BACKUP_RUNTIME=/data/${COMPOSE_PROJECT_NAME}/runtime-data
-     #- FOLDERS_TO_BACKUP_RUNTIME=/apps/performing-arts-ch/researchspace-runtime-data
       - KEEP_BACKUP_DAYS=${KEEP_BACKUP_DAYS}
       - S3_BUCKET_URL=${S3_BUCKET_URL}
       - ENDPOINT_URL=${ENDPOINT_URL}


### PR DESCRIPTION
This PR improves the backup process.

It is not necessary anymore to stop all running containers. Instead, a Blazegraph backup will be generated using the "[Online Backup](https://github.com/blazegraph/database/wiki/REST_API#online-backup) functionality of.

Additionally, the Alpine version of the backup Docker Image has been pinned to prevent breakage due to changes in the OS.